### PR TITLE
Added Puppet 2015.2 compatibility and new version of puppet-forge-server compatibility

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class forge_server::config {
   $log_dir = $::forge_server::log_dir
   $debug = $::forge_server::debug
   $scl = $::forge_server::scl
+  $provider = $::forge_server::provider
 
   file { '/etc/default/puppet-forge-server':
     ensure  => present,

--- a/templates/puppet-forge-server.default.erb
+++ b/templates/puppet-forge-server.default.erb
@@ -12,7 +12,7 @@ PARAMS="${PARAMS} --port <%= @port %>"
 
 <%- if @bind_host then -%>
 # Host name to bind to
-PARAMS="${PARAMS} --bind-host <%= @bind_host %>"
+PARAMS="${PARAMS} --bind <%= @bind_host %>"
 <%- end -%>
 
 <%- if @daemonize then -%>

--- a/templates/puppet-forge-server.initd.erb
+++ b/templates/puppet-forge-server.initd.erb
@@ -22,7 +22,7 @@ export GEM_PATH=/opt/rh/<%= @scl %>/root/usr/local/share/gems:/opt/rh/<%= @scl %
 export PATH=/opt/rh/<%= @scl %>/root/usr/bin:$PATH
 <%- end -%>
 
-<%- if @provider == "pe_gem" then -%>
+<%- if @provider == "pe_gem" or @provider == "puppet_gem" then -%>
 export PATH=$PATH:/opt/puppet/bin
 <%- end -%>
 

--- a/templates/puppet-forge-server.initd.erb
+++ b/templates/puppet-forge-server.initd.erb
@@ -22,7 +22,7 @@ export GEM_PATH=/opt/rh/<%= @scl %>/root/usr/local/share/gems:/opt/rh/<%= @scl %
 export PATH=/opt/rh/<%= @scl %>/root/usr/bin:$PATH
 <%- end -%>
 
-<%- if @provider == "pe_gem" or @provider == "puppet_gem" then -%>
+<%- if ( @provider == "pe_gem" or @provider == "puppet_gem" ) then -%>
 export PATH=$PATH:/opt/puppet/bin
 <%- end -%>
 

--- a/templates/puppet-forge-server.initd.erb
+++ b/templates/puppet-forge-server.initd.erb
@@ -22,8 +22,11 @@ export GEM_PATH=/opt/rh/<%= @scl %>/root/usr/local/share/gems:/opt/rh/<%= @scl %
 export PATH=/opt/rh/<%= @scl %>/root/usr/bin:$PATH
 <%- end -%>
 
-<%- if ( @provider == "pe_gem" or @provider == "puppet_gem" ) then -%>
-export PATH=$PATH:/opt/puppet/bin
+<%- if @provider == "pe_gem" then -%>
+export PATH=/opt/puppet/bin:$PATH
+<%- end -%>
+<%- if @provider == "puppet_gem" then -%>
+export PATH=/opt/puppetlabs/puppet/bin:$PATH
 <%- end -%>
 
 start() {


### PR DESCRIPTION
Modified the module to:
- allow the use of the puppet_gem provider in addition to the pe_gem provider
- fix paths to accommodate the new Puppet paths
- use the new parameters in the latest version of the puppet-forge-server rubygem
