### PR TITLE
Made gem package resource slightly more versatile

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,7 +87,7 @@ class forge_server (
   $log_dir          = $::forge_server::params::log_dir,
   $debug            = false,
   $provider         = 'gem',
-  $pkg_ensure       = 'latest',
+  $pkg_ensure       = 'present',
 ) inherits forge_server::params {
 
   # contain class and ordering

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,17 @@
 # [*debug*]
 #   Boolean to toggle debug
 #
+# [*provider*]
+#   Provider for the gem package install; defaults to gem; 
+#   can be set to pe_gem or puppet_gem depending on Puppet version
+#
+# [*pkg_ensure*]
+#   String specifying specific version number; possible values include:
+#     - 'latest': keep the gem package up to date (default)
+#     - '<version number>': install this specific version number
+#     - 'present': install the version available at the time of first run
+#       and do not update afterwards
+#
 # === Examples
 #
 #  class { '::forge_server':
@@ -75,7 +86,8 @@ class forge_server (
   $cache_basedir    = $::forge_server::params::cache_basedir,
   $log_dir          = $::forge_server::params::log_dir,
   $debug            = false,
-  $provider         = 'gem'
+  $provider         = 'gem',
+  $pkg_ensure       = 'latest',
 ) inherits forge_server::params {
 
   # contain class and ordering

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,8 +12,17 @@ class forge_server::package {
     }
   } else {
     package { $forge_server::package:
-      ensure   => present,
+      ensure   => $::forge_server::pkg_ensure,
       provider => $::forge_server::provider
+    }
+  }
+
+  # If we are ensuring the latest gem package, uninstall old versions
+  if $::forge_server::pkg_ensure == 'latest' {
+    exec { "gem cleanup ${::forge_server::package}":
+      path        => '/usr/bin',
+      refreshonly => true,
+      subscribe   => Package["$::forge_server::package"],
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,5 +13,5 @@ class forge_server::params {
   $cache_basedir = '/var/lib/puppet-forge-server/cache'
   $log_dir = '/var/log/puppet-forge-server'
   $provider = 'gem'
-  $pkg_ensure = 'latest'
+  $pkg_ensure = 'present'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,4 +13,5 @@ class forge_server::params {
   $cache_basedir = '/var/lib/puppet-forge-server/cache'
   $log_dir = '/var/log/puppet-forge-server'
   $provider = 'gem'
+  $pkg_ensure = 'latest'
 }


### PR DESCRIPTION
The following changes were made:
- Added some new help text in header
- Added new parameter 'pkg_ensure' to allow version locking or automatic updates for puppet-forge-server gem (default value is 'latest')
- Added cleanup for old gem versions ONLY IF pkg_ensure is set to 'latest'
