### PR TITLE
Fix for systemd servers, create tmpfiles.d config file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,14 +36,17 @@ class forge_server::config {
   }
 
   # On a systemd server create config file for tmpfiles.d
-  if $facts['operatingsystem'] in ['RedHat', 'CentOS', 'Fedora', 'Scientific', 'OracleLinux', 'SLC'] and
-  versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
-    file { '/usr/lib/tmpfiles.d/puppet-forge-server.conf':
-      ensure  => present,
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      content => template("${module_name}/puppet-forge-server.tmpfilesd.erb")
+  case $::operatingsystem {
+    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'OracleLinux', 'SLC': {
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+        file { '/usr/lib/tmpfiles.d/puppet-forge-server.conf':
+          ensure  => present,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          content => template("${module_name}/puppet-forge-server.tmpfilesd.erb")
+        }
+      }
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,7 +36,7 @@ class forge_server::config {
   }
 
   # On a systemd server create config file for tmpfiles.d
-  if $facts['operatingsystem'] in ['RedHat', 'CentOS', 'Fedora', 'Scientific', 'OracleLinux', 'SLC'] and 
+  if $facts['operatingsystem'] in ['RedHat', 'CentOS', 'Fedora', 'Scientific', 'OracleLinux', 'SLC'] and
   versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
     file { '/usr/lib/tmpfiles.d/puppet-forge-server.conf':
       ensure  => present,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ class forge_server::config {
   # Scope config variables for templates
   $user = $::forge_server::user
   $pidfile = $::forge_server::pidfile
+  $pid_dir = dirname($::forge_server::pidfile)
   $port = $::forge_server::port
   $bind_host = $::forge_server::bind_host
   $daemonize = $::forge_server::daemonize
@@ -32,6 +33,18 @@ class forge_server::config {
     group   => 'root',
     mode    => '0755',
     content => template("${module_name}/puppet-forge-server.initd.erb")
+  }
+
+  # On a systemd server create config file for tmpfiles.d
+  if $facts['operatingsystem'] in ['RedHat', 'CentOS', 'Fedora', 'Scientific', 'OracleLinux', 'SLC'] and 
+  versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
+    file { '/usr/lib/tmpfiles.d/puppet-forge-server.conf':
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template("${module_name}/puppet-forge-server.tmpfilesd.erb")
+    }
   }
 
 }

--- a/templates/puppet-forge-server.tmpfilesd.erb
+++ b/templates/puppet-forge-server.tmpfilesd.erb
@@ -1,0 +1,2 @@
+# puppet-forge-server
+d /var/run/puppet-forge-server 0775 <%= @user %> <%= @user %> -

--- a/templates/puppet-forge-server.tmpfilesd.erb
+++ b/templates/puppet-forge-server.tmpfilesd.erb
@@ -1,2 +1,2 @@
 # puppet-forge-server
-d /var/run/puppet-forge-server 0775 <%= @user %> <%= @user %> -
+d <%= @pid_dir %> 0755 <%= @user %> <%= @user %> -


### PR DESCRIPTION
On a systemd server (RHEL/Centos7), /var/run/puppet-forge-server is deleted after reboot.
Fix; create /usr/lib/tmpfiles.d/puppet-forge-server.conf to auto create this directory.
