### PR TITLE
systemd, proxy

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,14 +61,14 @@ class forge_server::config {
           content => template("${module_name}/puppet-forge-server.initd.erb")
         }
       }
-      default: {
-        file { '/etc/init.d/puppet-forge-server':
-          ensure  => present,
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0755',
-          content => template("${module_name}/puppet-forge-server.initd.erb")
-        }
+    }
+    default: {
+      file { '/etc/init.d/puppet-forge-server':
+        ensure  => present,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => template("${module_name}/puppet-forge-server.initd.erb")
       }
     }
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,14 +27,6 @@ class forge_server::config {
     content => template("${module_name}/puppet-forge-server.default.erb")
   }
 
-  file { '/etc/init.d/puppet-forge-server':
-    ensure  => present,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
-    content => template("${module_name}/puppet-forge-server.initd.erb")
-  }
-
   # On a systemd server create config file for tmpfiles.d
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'OracleLinux', 'SLC': {
@@ -46,8 +38,38 @@ class forge_server::config {
           mode    => '0644',
           content => template("${module_name}/puppet-forge-server.tmpfilesd.erb")
         }
+        file { '/etc/systemd/system/puppet-forge-server.service':
+          ensure  => present,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0640',
+          content => template("${module_name}/puppet-forge-server.service.erb"),
+          notify  => Exec['forge_systemctl-daemon-reload'],
+        }
+        exec { 'forge_systemctl-daemon-reload':
+          command     => 'systemctl daemon-reload',
+          path        => '/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin',
+          refreshonly => true,
+        }
+      }
+      else {
+        file { '/etc/init.d/puppet-forge-server':
+          ensure  => present,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0755',
+          content => template("${module_name}/puppet-forge-server.initd.erb")
+        }
+      }
+      default: {
+        file { '/etc/init.d/puppet-forge-server':
+          ensure  => present,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0755',
+          content => template("${module_name}/puppet-forge-server.initd.erb")
+        }
       }
     }
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@
 class forge_server::params {
   $package = 'puppet-forge-server'
   $user = 'forge'
+  $user_homedir = '/home/forge'
   $pidfile = '/var/run/puppet-forge-server/forge-server.pid'
   $port = 8080
   $bind_host = '127.0.0.1'
@@ -13,6 +14,7 @@ class forge_server::params {
   $cache_basedir = '/var/lib/puppet-forge-server/cache'
   $log_dir = '/var/log/puppet-forge-server'
   $provider = 'gem'
+  $http_proxy    = undef
   $scl_install_timeout = 300
   $scl_install_retries = 1
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -7,6 +7,14 @@ class forge_server::user {
     ensure => present,
     gid    => $::forge_server::user
   }
+
+  # have to create a home dir or else systemd unit file will not start
+  file { $::forge_server::user_homedir:
+    ensure => directory,
+    owner  => $::forge_server::user,
+    group  => $::forge_server::user,
+  }
+
   group { $::forge_server::user:
     ensure => present
   }

--- a/templates/puppet-forge-server.initd.erb
+++ b/templates/puppet-forge-server.initd.erb
@@ -42,6 +42,12 @@ export PATH=/opt/puppet/bin:$PATH
 export PATH=/opt/puppetlabs/puppet/bin:$PATH
 <%- end -%>
 
+<%- if @http_proxy -%>
+export HTTP_PROXY=<%= @http_proxy %>
+export HTTPS_PROXY=<%= @http_proxy %>
+<%- end -%>
+
+
 start() {
         echo -n "Starting $prog: "
         daemon --user=<%= @user %> --pidfile=<%= @pidfile %> "$prog $PARAMS"

--- a/templates/puppet-forge-server.service.erb
+++ b/templates/puppet-forge-server.service.erb
@@ -1,0 +1,34 @@
+[Unit]
+Description=Puppet Forge Server
+After=network.target
+
+[Service]
+<%- if @scl then -%>
+# SCL is a bit hacky
+Environment=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rh/<%= @scl %>/root/usr/lib64:/opt/rh/<%= @scl %>/root/usr/local/share/gems:/opt/rh/<%= @scl %>/root/usr/share/gems
+Environment=GEM_PATH=/opt/rh/<%= @scl %>/root/usr/local/share/gems:/opt/rh/<%= @scl %>/root/usr/share/gems
+Environment=PATH=/opt/rh/<%= @scl %>/root/usr/bin:$PATH
+<%- end -%>
+
+<%- if @provider == "pe_gem" then -%>
+Environment=PATH=/opt/puppet/bin:$PATH
+<%- end -%>
+<%- if @provider == "puppet_gem" then -%>
+Environment=PATH=/opt/puppetlabs/puppet/bin:$PATH
+<%- end -%>
+
+Type=simple
+User=<%= @user %>
+Group=<%= @user %>
+ExecStart=/bin/bash -c 'puppet-forge-server <%- if @pidfile then -%>--pidfile "<%= @pidfile -%>"<%- end -%><%- if @port then -%> --port <%= @port %><%- end -%><%- if @bind_host then -%> --bind <%= @bind_host -%><%- end -%><%- if @module_directory then -%><%- if @module_directory.is_a? Array then @module_directory.each do |md| -%> --module-dir "<%= md %>"<%- end else -%> --module-dir "<%= @module_directory %>"<%- end end -%><%- if @proxy then -%><%- if @proxy.is_a? Array then @proxy.each do |pr| -%> --proxy <%= pr %><%- end else -%> --proxy <%= @proxy %><%- end end -%><%- if @cache_basedir then -%> --cache-basedir "<%= @cache_basedir %>"<%- end -%><%- if @log_dir then -%> --log-dir "<%= @log_dir %>"<%- end -%><%- if @debug then -%> --debug<%- end -%>'
+
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec=300
+
+<%- if @http_proxy -%>
+Environment=HTTP_PROXY=<%= @http_proxy %>
+Environment=HTTPS_PROXY=<%= @http_proxy %>
+<%- end -%>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* adds a systemd unit file
* adds proxy support to init script and unit-file

the unit files 'ExecStart' is a bit hacky, because you cannot append
variables like you do in the default-config and use it in unit files.
See https://github.com/systemd/systemd/issues/1082 for more info.

This also adds a proxy-option environment variable.