### PR TITLE
Made http_proxy parameter overridable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,7 @@ class forge_server::config {
   $bind_host = $::forge_server::bind_host
   $daemonize = $::forge_server::daemonize
   $module_directory = $::forge_server::module_directory
+  $http_proxy = $::forge_server::http_proxy
   $proxy = $::forge_server::proxy
   $cache_basedir = $::forge_server::cache_basedir
   $log_dir = $::forge_server::log_dir

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,9 @@
 # [*module_directory*]
 #   Directory of modules to serve, can be an array of directories
 #
+# [*http_proxy*]
+#   Use proxyserver for http(s) connections
+#
 # [*proxy*]
 #   Proxy requests to this upstream forge url
 #
@@ -79,6 +82,7 @@ class forge_server (
   $bind_host           = $::forge_server::params::bind_host,
   $daemonize           = true,
   $module_directory    = $::forge_server::params::module_directory,
+  $http_proxy          = $::forge_server::params::http_proxy,
   $proxy               = $::forge_server::params::proxy,
   $cache_basedir       = $::forge_server::params::cache_basedir,
   $log_dir             = $::forge_server::params::log_dir,


### PR DESCRIPTION
http_proxy for upstream servers was present in params and templates, but could not be set via a class parameter.

Introduced a class parameter so that this can be configured.

Thanks for the module!