### PR TITLE
Update minimum ver to update against XSS attacks

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,8 @@
 # Default settings
 #
 class forge_server::params {
-  $package = 'puppet-forge-server'
+  $lkg_package = '1.9.1'
+  $package = "puppet-forge-server:>=${lkg_package}"
   $user = 'forge'
   $user_homedir = '/home/forge'
   $pidfile = '/var/run/puppet-forge-server/forge-server.pid'


### PR DESCRIPTION
Update the puppet manifest to force version over a LKG (last known good). In this case 1.9.1 would contain https://github.com/unibet/puppet-forge-server/pull/65 to protect against XSS attacks.

Reminders:
  - Build & update gem in rubygems.org
  - Build & update Puppet manifest in Forge