### PR TITLE
Added missing packages.

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -3,6 +3,13 @@
 # Installs puppet-forge-server
 #
 class forge_server::package {
+  package {'ruby-devel':
+    ensure => present,
+  }
+
+  package {'gcc':
+    ensure => present,
+  }
 
   if $::forge_server::scl {
     exec { 'scl_install_forge_server':


### PR DESCRIPTION
On a minimum install CentOS 7 system the gcc and ruby-devel packages are not installed.

When installing the puppet-forge-server gem the installation fails with the following errors:

Initially the error is:

```
[root@localhost ~]# cd /etc/puppet/manifests/
[root@localhost manifests]# puppet apply --parser future site.pp
Notice: Compiled catalog for localhost in environment production in 1.15 seconds
Error: Execution of '/usr/bin/gem install --no-rdoc --no-ri puppet-forge-server' returned 1: Building native extensions.  This could take a while...
ERROR:  Error installing puppet-forge-server:
	ERROR: Failed to build gem native extension.

    /usr/bin/ruby extconf.rb
mkmf.rb can't find header files for ruby at /usr/share/include/ruby.h


Gem files will remain installed in /usr/local/share/gems/gems/json-1.8.6 for inspection.
Results logged to /usr/local/share/gems/gems/json-1.8.6/ext/json/ext/generator/gem_make.out
Error: /Stage[main]/Forge_server::Package/Package[puppet-forge-server]/ensure: change from absent to present failed: Execution of '/usr/bin/gem install --no-rdoc --no-ri puppet-forge-server' returned 1: Building native extensions.  This could take a while...
ERROR:  Error installing puppet-forge-server:
	ERROR: Failed to build gem native extension.

    /usr/bin/ruby extconf.rb
mkmf.rb can't find header files for ruby at /usr/share/include/ruby.h


Gem files will remain installed in /usr/local/share/gems/gems/json-1.8.6 for inspection.
Results logged to /usr/local/share/gems/gems/json-1.8.6/ext/json/ext/generator/gem_make.out
```


This error can be solved by installing the ruby-devel package.

Then the installation fails with

```
[root@localhost manifests]# puppet apply --parser future site.pp
Notice: Compiled catalog for localhost in environment production in 1.13 seconds
Error: Execution of '/usr/bin/gem install --no-rdoc --no-ri puppet-forge-server' returned 1: Building native extensions.  This could take a while...
ERROR:  Error installing puppet-forge-server:
	ERROR: Failed to build gem native extension.

    /usr/bin/ruby extconf.rb
creating Makefile

make "DESTDIR="
gcc -I. -I/usr/include -I/usr/include/ruby/backward -I/usr/include -I. -DJSON_GENERATOR    -fPIC -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mtune=generic -fPIC -m64 -o generator.o -c generator.c
make: gcc: Command not found
make: *** [generator.o] Error 127


Gem files will remain installed in /usr/local/share/gems/gems/json-1.8.6 for inspection.
Results logged to /usr/local/share/gems/gems/json-1.8.6/ext/json/ext/generator/gem_make.out
Error: /Stage[main]/Forge_server::Package/Package[puppet-forge-server]/ensure: change from absent to present failed: Execution of '/usr/bin/gem install --no-rdoc --no-ri puppet-forge-server' returned 1: Building native extensions.  This could take a while...
ERROR:  Error installing puppet-forge-server:
	ERROR: Failed to build gem native extension.

    /usr/bin/ruby extconf.rb
creating Makefile

make "DESTDIR="
gcc -I. -I/usr/include -I/usr/include/ruby/backward -I/usr/include -I. -DJSON_GENERATOR    -fPIC -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mtune=generic -fPIC -m64 -o generator.o -c generator.c
make: gcc: Command not found
make: *** [generator.o] Error 127
```

After installing the missing packages the installation finshes successfully

```
[root@localhost manifests]# puppet apply --parser future site.pp
Notice: Compiled catalog for localhost in environment production in 1.12 seconds
Notice: /Stage[main]/Forge_server::Package/Package[puppet-forge-server]/ensure: created
Notice: /Stage[main]/Forge_server::Config/File[/etc/default/puppet-forge-server]/ensure: created
Notice: /Stage[main]/Forge_server::Config/File[/usr/lib/tmpfiles.d/puppet-forge-server.conf]/ensure: created
Notice: /Stage[main]/Forge_server::Config/File[/etc/systemd/system/puppet-forge-server.service]/ensure: created
Notice: /Stage[main]/Forge_server::Config/Exec[forge_systemctl-daemon-reload]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Forge_server::Files/Forge_server::Mkdir[/mnt/forge/cache]/Exec[forge_server_mkdir_p_/mnt/forge/cache]/returns: executed successfully
Notice: /Stage[main]/Forge_server::Files/Forge_server::Mkdir[/mnt/forge/modules]/Exec[forge_server_mkdir_p_/mnt/forge/modules]/returns: executed successfully
Notice: /Stage[main]/Forge_server::Files/File[/mnt/forge/modules]/owner: owner changed 'root' to 'forge'
Notice: /Stage[main]/Forge_server::Files/File[/mnt/forge/modules]/group: group changed 'root' to 'forge'
Notice: /Stage[main]/Forge_server::Files/File[/mnt/forge/cache]/owner: owner changed 'root' to 'forge'
Notice: /Stage[main]/Forge_server::Files/File[/mnt/forge/cache]/group: group changed 'root' to 'forge'
Notice: /Stage[main]/Forge_server::Files/Forge_server::Mkdir[/var/log/forge]/Exec[forge_server_mkdir_p_/var/log/forge]/returns: executed successfully
Notice: /Stage[main]/Forge_server::Files/File[/var/log/forge]/owner: owner changed 'root' to 'forge'
Notice: /Stage[main]/Forge_server::Files/File[/var/log/forge]/group: group changed 'root' to 'forge'
Notice: /Stage[main]/Forge_server::Files/File[/var/log/forge]/mode: mode changed '0755' to '0700'
Notice: /File[/var/log/forge]/seluser: seluser changed 'unconfined_u' to 'system_u'
Notice: /Stage[main]/Forge_server::Files/Forge_server::Mkdir[/var/run/puppet-forge-server]/Exec[forge_server_mkdir_p_/var/run/puppet-forge-server]/returns: executed successfully
Notice: /Stage[main]/Forge_server::Files/File[/var/run/puppet-forge-server]/owner: owner changed 'root' to 'forge'
Notice: /Stage[main]/Forge_server::Files/File[/var/run/puppet-forge-server]/group: group changed 'root' to 'forge'
Notice: /File[/var/run/puppet-forge-server]/seluser: seluser changed 'unconfined_u' to 'system_u'
Notice: /Stage[main]/Forge_server::Service/Service[puppet-forge-server]/ensure: ensure changed 'stopped' to 'running'
Notice: Finished catalog run in 9.56 seconds
[root@localhost manifests]#
```