### PR TITLE
Make forge user and group more customisable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,15 @@
 # [*debug*]
 #   Boolean to toggle debug
 #
+# [*manage_user*]
+#   Boolean to toggle management of user and group resources
+#
+# [*userid*]
+#   Fixed UID of the forge user
+#
+# [*groupid*]
+#   Fixed GID of the forge group
+#
 # === Examples
 #
 #  class { '::forge_server':
@@ -87,7 +96,10 @@ class forge_server (
   $cache_basedir       = $::forge_server::params::cache_basedir,
   $log_dir             = $::forge_server::params::log_dir,
   $debug               = false,
-  $provider            = 'gem'
+  $provider            = 'gem',
+  $manage_user         = true,
+  $userid              = undef,
+  $groupid             = undef
 ) inherits forge_server::params {
 
   if $scl {

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -3,19 +3,23 @@
 # Manages the forge user
 #
 class forge_server::user {
-  user { $::forge_server::user:
-    ensure => present,
-    gid    => $::forge_server::user
-  }
+  if $::forge_server::manage_user {
+    user { $::forge_server::user:
+      ensure => present,
+      uid    => $::forge_server::userid,
+      gid    => $::forge_server::user
+    }
 
-  # have to create a home dir or else systemd unit file will not start
-  file { $::forge_server::user_homedir:
-    ensure => directory,
-    owner  => $::forge_server::user,
-    group  => $::forge_server::user,
-  }
+    # have to create a home dir or else systemd unit file will not start
+    file { $::forge_server::user_homedir:
+      ensure => directory,
+      owner  => $::forge_server::user,
+      group  => $::forge_server::user,
+    }
 
-  group { $::forge_server::user:
-    ensure => present
+    group { $::forge_server::user:
+      gid    => $::forge_server::groupid,
+      ensure => present
+    }
   }
 }


### PR DESCRIPTION
Aim: Make it possible for users of this module to have more control over OS user and group under which forge-server runs.

Following Changes where made:

- Add $manage_user boolean to toggle resources in user.pp
- Add $userid and $groupid parameters, making it possible to control these attributes

Default values where chosen so as not to have any impact if you do not use these parameters