### PR TITLE
SLES support documentation and lint fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This module installs the puppet-forge-server gem and runs the service as a daemo
 ### What forge_server affects
 
 * Unprivileged forge user to run the daemon
-* Gem installation either in system ruby or specific SCL
+* Gem installation either in system ruby, Puppet ruby or specific SCL
 * Manages the puppet-forge-server service
 
 ### Setup Requirements
@@ -51,6 +51,14 @@ To install puppet-forge-server:
 
 ```
 class { '::forge_server': }
+```
+
+To install using Puppet ruby:
+
+```
+class { '::forge_server':
+  provider => 'puppet_gem',
+}
 ```
 
 ## Reference

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -65,7 +65,7 @@ class forge_server::config {
     }
     'SLES': {
       if versioncmp($::operatingsystemmajrelease, '12') >= 0 {
-         file { '/usr/lib/tmpfiles.d/puppet-forge-server.conf':
+        file { '/usr/lib/tmpfiles.d/puppet-forge-server.conf':
           ensure  => present,
           owner   => 'root',
           group   => 'root',
@@ -84,7 +84,7 @@ class forge_server::config {
           command     => 'systemctl daemon-reload',
           path        => '/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin',
           refreshonly => true,
-        }       
+        }
       }
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,10 @@
     {
     "operatingsystem": "Ubuntu",
     "operatingsystemrelease": [ "14.04", "12.04" ]
+    },
+    {
+    "operatingsystem": "SLES",
+    "operatingsystemrelease": [ "12" ]
     }
   ]
 }


### PR DESCRIPTION
SLES support was already added, but not mentioned on metadata.json
Usage example on how to use Puppet ruby
Lint cleanup